### PR TITLE
Add field for uniform title

### DIFF
--- a/conf/schema/local_explicit_fields.xml
+++ b/conf/schema/local_explicit_fields.xml
@@ -99,6 +99,7 @@
 <field name="title_common"     type="text"  indexed="true" stored="true" multiValued="true"/>
 <field name="title_equiv"      type="text"  indexed="true" stored="true"  multiValued="true" omitNorms="true"/>
 <field name="title"            type="text"          indexed="true"  stored="true"  multiValued="true" />
+<field name="uniformTitle"            type="text"          indexed="true"  stored="true"  multiValued="true" />
 <field name="titleSort"        type="exactishSort" indexed="true"  stored="false" multiValued="false"/>
 <field name="vtitle"           type="string"        indexed="false" stored="true" multiValued="false" />
 <field name="titleProper"      type="text_no_stem_or_synonyms"    indexed="true"  stored="false" multiValued="true" />


### PR DESCRIPTION
Librarians have asked about an easier way to query it; we might be able to boost just the uniform title (which is already
part of the title_top grouping). This doesn't change any searches, just makes it available for indexing.