### PR TITLE
Be more aggressive about normalizing unique identifiers

### DIFF
--- a/conf/schema.xml
+++ b/conf/schema.xml
@@ -107,7 +107,12 @@
 
     <!ENTITY remove_all_non_numbers '
       <filter class="solr.PatternReplaceFilterFactory" pattern="[^\p{N}]" replacement="" replace="all"/>
-    '>
+     '>
+
+    <!ENTITY remove_all_non_issn_chars '
+      <filter class="solr.PatternReplaceFilterFactory" pattern="[^\p{N}xX]" replacement="" replace="all"/>
+     '>
+
 
     <!ENTITY remove_all_non_letters '
       <filter class="solr.PatternReplaceFilterFactory" pattern="[^\p{L}]" replacement="" replace="all"/>
@@ -455,19 +460,25 @@
 
     <fieldType name="isbn" class="solr.TextField">
         <analyzer>
-            <tokenizer class="solr.PatternTokenizerFactory" pattern="[;,]\s*" />
-            <filter class="edu.umich.lib.solr_filters.ISBNNormalizerFilterFactory"/>
+          &tokenize_into_one_big_token;
+          &normalize_numeric_digits;
+          &trim_leading_whitespace_and_punctuation;
+          &trim_trailing_whitespace_and_punctuation;
+          <filter class="edu.umich.lib.solr_filters.ISBNNormalizerFilterFactory"/>
             &remove_duplicates_at_same_position;
-            <filter class="solr.LengthFilterFactory" min="13" max="13" />
+          <filter class="solr.LengthFilterFactory" min="13" max="13" />
         </analyzer>
     </fieldType>
 
 
     <fieldType name="lccn" class="solr.TextField">
-        <analyzer>
-            <tokenizer class="solr.KeywordTokenizerFactory"/>
-            <filter class="edu.umich.lib.solr_filters.LCCNNormalizerFilterFactory"/>
-        </analyzer>
+      <analyzer>
+        &tokenize_into_one_big_token;
+        &normalize_numeric_digits;
+        &trim_leading_whitespace_and_punctuation;
+        &trim_trailing_whitespace_and_punctuation;
+        <filter class="edu.umich.lib.solr_filters.LCCNNormalizerFilterFactory"/>
+      </analyzer>
     </fieldType>
 
     <fieldType name="lc_callnumber_sortable" class="solr.TextField">
@@ -491,6 +502,29 @@
     </fieldType>
 
 
+
+    <fieldType name="oclc" class="solr.TextField">
+        <analyzer>
+          &tokenize_into_one_big_token;
+          &normalize_numeric_digits;
+          &remove_all_non_numbers;
+          <filter class="solr.PatternReplaceFilterFactory"
+            pattern="^[^\p{N}]*0*(\p{N}+).*$" replacement="$1"/>
+        </analyzer>
+    </fieldType>
+
+    <!-- Remove all non-numbers except Xx, lowercase, and only accept if the result is 8 chars -->
+   <fieldType name="issn" class="solr.TextField">
+        <analyzer>
+          &tokenize_into_one_big_token;
+          &normalize_numeric_digits;
+          &remove_all_non_issn_chars;
+          <filter class="solr.LowerCaseFilterFactory"/>
+          <filter class="solr.LengthFilterFactory" min="8" max="8"/>
+        </analyzer>
+    </fieldType>
+
+    
     <!-- =============================================================
                    GENERIC NUMERIC IDENTIFIER TYPES
     ============================================================== -->

--- a/conf/schema/local_explicit_fields.xml
+++ b/conf/schema/local_explicit_fields.xml
@@ -29,9 +29,9 @@
 <field name="ctrlnum"      type="exactish"   indexed="true" stored="true"  multiValued="true"/>
 <field name="rptnum"       type="exactish"   indexed="true" stored="true"  multiValued="true"/>
 <field name="sdrnum"       type="exactish"   indexed="true" stored="true"  multiValued="true"/>
-<field name="oclc"         type="integer_no_leading_zeros"        indexed="true" stored="true"  multiValued="true"/>
+<field name="oclc"         type="oclc"        indexed="true" stored="true"  multiValued="true"/>
 <field name="isbn"         type="isbn"         indexed="true" stored="true"  multiValued="true"/>
-<field name="issn"         type="numericID"         indexed="true" stored="true"  multiValued="true"/>
+<field name="issn"         type="issn"         indexed="true" stored="true"  multiValued="true"/>
 <field name="isn_related"  type="numericID"         indexed="true" stored="true" multiValued="true"/>
 <field name="barcode"      type="exactish"   indexed="true" stored="true" multiValued="true" />
     <!-- HT Stuff -->


### PR DESCRIPTION
The initial code tried to allow a lot of potentially-valid things
(like comma-separated lists of isxns) which were, in practice,
never used.

New code:
  * More aggressively resists tokenization of isbn parts
  * Drops all non-legal issn chars before normalization and
    then explicitly demands exactly 8 characters
  * Creates an explicit oclc type that does, more or less, what
    the existing integer_no_leading_zeros type does but more
    resistant to tokenization and non-normal numeric characters.