### PR TITLE
Adding support for a *_bb field for best bets.

### DIFF
--- a/conf/schema/local_dynamic_fields.xml
+++ b/conf/schema/local_dynamic_fields.xml
@@ -1,2 +1,3 @@
 <!-- This fine included so attempts to import the default
      filename in schema.xml don't blow up -->
+<dynamicField name="*_bb" type="best_bets_rank"/>

--- a/conf/schema/primative_types.xml
+++ b/conf/schema/primative_types.xml
@@ -9,9 +9,11 @@
 <fieldType class="solr.TrieIntField" name="int" precisionStep="0" positionIncrementGap="0"   docValues="true"/>
 <fieldType class="solr.TrieLongField" name="long" precisionStep="0" positionIncrementGap="0" docValues="true"/>
 
-
 <fieldType class="solr.StrField" name="string" stored="false" indexed="false" multiValued="false" docValues="true"/>
 <fieldType class="solr.StrField" name="facet"  stored="false" indexed="true" multiValued="true" docValues="true"/>
+
+<fieldType class="solr.TrieIntField" name="best_bets_rank" indexed="true" stored="true"
+    precisionStep="0" positionIncrementGap="0" multiValued="false" docValues="true"/>
 
 <fieldType class="solr.TrieDateField" name="single_date_stored" stored="false" indexed="false" multiValued="false" docValues="true"/>
 


### PR DESCRIPTION
This is for SEARCH-1288.  Browse by HLB/Academic Discipline for journals uses a sort by manually curated rank, then sort alphabetically.  Since the rank is category specific, that means one field for each category, thus the dynamic field.  This should end up creating a little more than 100 new fields, but they generally only have 0-5 items assigned, so probably fewer than 1000 records will have values assigned to any of these categories.