### PR TITLE
Add stored fields lc_subject_display and non_lc_subject_display

### DIFF
--- a/conf/schema/local_explicit_fields.xml
+++ b/conf/schema/local_explicit_fields.xml
@@ -196,11 +196,15 @@
 <field name="hlb3"    type="text"       indexed="true" stored="false" multiValued="true"  omitNorms="true" />
 <field name="hlb3Str" type="string"     indexed="true" stored="true" multiValued="true"                   />
 <field name="hlb3Delimited" type="string" indexed="false" stored="true" multiValued="true" termVectors="false"/>
-<field name="lc_subject" type="lc_subject" indexed="true" stored="true" multiValued="true"/>
 <copyField source="topic" dest="topicStr"/>
 <copyField source="topic" dest="topicProper"/>
 <copyField source="hlb3" dest="hlb3Str"/>
 <copyField source="genre" dest="genreStr"/>
+
+<field name="lc_subject_display"     type="string" indexed="false" stored="true" multiValued="true"/>
+<field name="non_lc_subject_display" type="string" indexed="false" stored="true" multiValued="true"/>
+
+
 
 
     <!-- Time and Place -->


### PR DESCRIPTION
Adds purely-stored fields for displaying subjects. A temporary measure for display purposes until we get
further into search/facet/browse of LC subjects.

Pairs with https://github.com/mlibrary/umich_catalog_indexing/pull/14