### PR TITLE
Title initial forgiving

### DIFF
--- a/conf/schema.xml
+++ b/conf/schema.xml
@@ -374,6 +374,23 @@
       </analyzer>
     </fieldType>
 
+		<!-- A single token, ascii-ified and downcased -->
+
+		<fieldType name="folded_single_token" class="solr.TextField" positionIncrementGap="&pig;">
+			<analyzer>
+				&standard_single_token_tokenizer;
+				&icu_case_folding_and_normalization;
+			</analyzer>
+		</fieldType>
+
+
+		<fieldType name="folded_single_char" class="solr.TextField" positionIncrementGap="&pig;">
+			<analyzer>
+			&standard_single_token_tokenizer;
+			&icu_case_folding_and_normalization;
+			<filter class="solr.LengthFilterFactory" min="1" max="1" />
+			</analyzer>
+		</fieldType>
 
     <!--
         field type: exactishSort

--- a/conf/schema/local_explicit_fields.xml
+++ b/conf/schema/local_explicit_fields.xml
@@ -178,7 +178,8 @@
 <field name="serialTitle_common_l"    type="text_leftanchored" indexed="true" stored="false" multiValued="true" />
 <field name="serialTitle_common_exact" type="fully_anchored"  indexed="true"  stored="false" multiValued="true"/>
 
-<field name="title_initial" type="folded_single_char" indexed="true" stored="true" multiValued="false"/>
+<field name="title_initial" type="folded_single_token" indexed="true" stored="true" multiValued="false"/>
+
 
 <copyField source="serialTitle" dest="serialTitleProper"/>
 <copyField source="serialTitle_common" dest="serialTitle_common_exact"/>

--- a/conf/schema/local_explicit_fields.xml
+++ b/conf/schema/local_explicit_fields.xml
@@ -178,7 +178,7 @@
 <field name="serialTitle_common_l"    type="text_leftanchored" indexed="true" stored="false" multiValued="true" />
 <field name="serialTitle_common_exact" type="fully_anchored"  indexed="true"  stored="false" multiValued="true"/>
 
-<field name="title_initial" type="string" indexed="true" stored="true" multiValued="false"/>
+<field name="title_initial" type="folded_single_char" indexed="true" stored="true" multiValued="false"/>
 
 <copyField source="serialTitle" dest="serialTitleProper"/>
 <copyField source="serialTitle_common" dest="serialTitle_common_exact"/>


### PR DESCRIPTION
Provide a more forgiving type for title_initial (used for A-Z journals list) that does diacritic and case folding