### PR TITLE
Sort missing last for best bets types

### DIFF
--- a/conf/schema/primative_types.xml
+++ b/conf/schema/primative_types.xml
@@ -13,7 +13,7 @@
 <fieldType class="solr.StrField" name="facet"  stored="false" indexed="true" multiValued="true" docValues="true"/>
 
 <fieldType class="solr.TrieIntField" name="best_bets_rank" indexed="true" stored="true"
-    precisionStep="0" positionIncrementGap="0" multiValued="false" docValues="true"/>
+    precisionStep="0" positionIncrementGap="0" multiValued="false" docValues="true" sortMissingLast="true"/>
 
 <fieldType class="solr.TrieDateField" name="single_date_stored" stored="false" indexed="false" multiValued="false" docValues="true"/>
 


### PR DESCRIPTION
I missed this before.  Since this field is so sparse, it'll need to put records without it last.