### PR TITLE
Automatically add the date of index into `catalog_index_date`

### DIFF
--- a/conf/schema/local_explicit_fields.xml
+++ b/conf/schema/local_explicit_fields.xml
@@ -8,6 +8,8 @@
 <field name="id_int"          type="long"      indexed="true" stored="true"/>
 <copyField source="id" dest="id_int"/>
 
+<field name="catalog_index_date" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
+
 <field name="fullrecord"      type="string"     indexed="false" stored="true" docValues="false"/>
 
 <field name="allfields"       type="text"       indexed="true" stored="false"/>


### PR DESCRIPTION
This will be useful for figuring out when things were indexed so
we can populate other datastores or systems.